### PR TITLE
chore: Rename to '--config-file' flag for scaffold command

### DIFF
--- a/cmd/modulectl/scaffold/cmd_test.go
+++ b/cmd/modulectl/scaffold/cmd_test.go
@@ -84,8 +84,10 @@ func Test_Execute_ParsesOptions(t *testing.T) {
 
 func Test_Execute_ParsesShortOptions(t *testing.T) {
 	directory := testutils.RandomName(10)
+	configFile := testutils.RandomName(10)
 	os.Args = []string{
 		"scaffold",
+		"-c", configFile,
 		"-d", directory,
 		"-o",
 	}
@@ -95,6 +97,7 @@ func Test_Execute_ParsesShortOptions(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 
+	assert.Equal(t, configFile, svc.opts.ModuleConfigFileName)
 	assert.Equal(t, directory, svc.opts.Directory)
 	assert.True(t, svc.opts.ModuleConfigFileOverwrite)
 }

--- a/cmd/modulectl/scaffold/cmd_test.go
+++ b/cmd/modulectl/scaffold/cmd_test.go
@@ -56,7 +56,7 @@ func Test_Execute_ParsesOptions(t *testing.T) {
 	os.Args = []string{
 		"scaffold",
 		"--directory", directory,
-		"--module-config", moduleConfigFile,
+		"--config-file", moduleConfigFile,
 		"--overwrite",
 		"--gen-manifest", manifestFile,
 		"--gen-default-cr=" + defaultCRFile,

--- a/cmd/modulectl/scaffold/flags.go
+++ b/cmd/modulectl/scaffold/flags.go
@@ -12,7 +12,7 @@ const (
 	DirectoryFlagDefault = "./"
 	directoryFlagUsage   = `Specifies the target directory where the scaffolding shall be generated (default "./").`
 
-	ModuleConfigFileFlagName    = "module-config"
+	ModuleConfigFileFlagName    = "config-file"
 	ModuleConfigFileFlagDefault = "scaffold-module-config.yaml"
 	moduleConfigFileFlagUsage   = `Specifies the name of the generated module configuration file (default "scaffold-module-config.yaml").`
 

--- a/cmd/modulectl/scaffold/flags.go
+++ b/cmd/modulectl/scaffold/flags.go
@@ -13,6 +13,7 @@ const (
 	directoryFlagUsage   = `Specifies the target directory where the scaffolding shall be generated (default "./").`
 
 	ModuleConfigFileFlagName    = "config-file"
+	moduleConfigFileFlagShort   = "c"
 	ModuleConfigFileFlagDefault = "scaffold-module-config.yaml"
 	moduleConfigFileFlagUsage   = `Specifies the name of the generated module configuration file (default "scaffold-module-config.yaml").`
 
@@ -50,7 +51,7 @@ const (
 
 func parseFlags(flags *pflag.FlagSet, opts *scaffold.Options) {
 	flags.StringVarP(&opts.Directory, DirectoryFlagName, directoryFlagShort, DirectoryFlagDefault, directoryFlagUsage)
-	flags.StringVar(&opts.ModuleConfigFileName, ModuleConfigFileFlagName, ModuleConfigFileFlagDefault, moduleConfigFileFlagUsage)
+	flags.StringVarP(&opts.ModuleConfigFileName, ModuleConfigFileFlagName, moduleConfigFileFlagShort, ModuleConfigFileFlagDefault, moduleConfigFileFlagUsage)
 	flags.BoolVarP(&opts.ModuleConfigFileOverwrite, ModuleConfigFileOverwriteFlagName, moduleConfigFileOverwriteFlagShort, ModuleConfigFileOverwriteFlagDefault, moduleConfigFileOverwriteFlagUsage)
 	flags.StringVar(&opts.ManifestFileName, ManifestFileFlagName, ManifestFileFlagDefault, manifestFileFlagUsage)
 	flags.StringVar(&opts.DefaultCRFileName, DefaultCRFlagName, DefaultCRFlagDefault, defaultCRFlagUsage)

--- a/cmd/modulectl/scaffold/long.txt
+++ b/cmd/modulectl/scaffold/long.txt
@@ -8,7 +8,7 @@ allowing for a tailored scaffolding experience according to the specific needs o
 The command generates or uses the following files:
  - Module Config:
 	Enabled: Always
-	Adjustable with flag: --module-config=VALUE
+	Adjustable with flag: --config-file=VALUE
 	Generated when: The file doesn't exist or the --overwrite=true flag is provided
 	Default file name: scaffold-module-config.yaml
  - Manifest:

--- a/docs/gen-docs/modulectl_scaffold.md
+++ b/docs/gen-docs/modulectl_scaffold.md
@@ -69,13 +69,13 @@ Generate a scaffold with a manifest file, default CR and security-scanners confi
 ## Flags
 
 ```bash
+-c, --config-file string           Specifies the name of the generated module configuration file (default "scaffold-module-config.yaml").
 -d, --directory string             Specifies the target directory where the scaffolding shall be generated (default "./").
     --gen-default-cr string        Specifies the default CR in the generated module config. A blank default CR file is generated if it doesn't exist (default "default-cr.yaml").
     --gen-manifest string          Specifies the manifest in the generated module config. A blank manifest file is generated if it doesn't exist (default "manifest.yaml").
     --gen-security-config string   Specifies the security file in the generated module config. A scaffold security config file is generated if it doesn't exist (default "sec-scanners-config.yaml").
 -h, --help                         Provides help for the scaffold command.
     --module-channel string        Specifies the module channel in the generated module config file (default "regular").
-    --config-file string           Specifies the name of the generated module configuration file (default "scaffold-module-config.yaml").
     --module-name string           Specifies the module name in the generated config file (default "kyma-project.io/module/mymodule").
     --module-version string        Specifies the module version in the generated module config file (default "0.0.1").
 -o, --overwrite                    Specifies if the command overwrites an existing module configuration file.

--- a/docs/gen-docs/modulectl_scaffold.md
+++ b/docs/gen-docs/modulectl_scaffold.md
@@ -17,7 +17,7 @@ allowing for a tailored scaffolding experience according to the specific needs o
 The command generates or uses the following files:
  - Module Config:
 	Enabled: Always
-	Adjustable with flag: --module-config=VALUE
+	Adjustable with flag: --config-file=VALUE
 	Generated when: The file doesn't exist or the --overwrite=true flag is provided
 	Default file name: scaffold-module-config.yaml
  - Manifest:
@@ -75,7 +75,7 @@ Generate a scaffold with a manifest file, default CR and security-scanners confi
     --gen-security-config string   Specifies the security file in the generated module config. A scaffold security config file is generated if it doesn't exist (default "sec-scanners-config.yaml").
 -h, --help                         Provides help for the scaffold command.
     --module-channel string        Specifies the module channel in the generated module config file (default "regular").
-    --module-config string         Specifies the name of the generated module configuration file (default "scaffold-module-config.yaml").
+    --config-file string           Specifies the name of the generated module configuration file (default "scaffold-module-config.yaml").
     --module-name string           Specifies the module name in the generated config file (default "kyma-project.io/module/mymodule").
     --module-version string        Specifies the module version in the generated module config file (default "0.0.1").
 -o, --overwrite                    Specifies if the command overwrites an existing module configuration file.

--- a/tests/e2e/scaffold/scaffold_suite_test.go
+++ b/tests/e2e/scaffold/scaffold_suite_test.go
@@ -47,7 +47,7 @@ func (cmd *scaffoldCmd) execute() error {
 	}
 
 	if cmd.moduleConfigFileFlag != "" {
-		args = append(args, "--module-config="+cmd.moduleConfigFileFlag)
+		args = append(args, "--config-file="+cmd.moduleConfigFileFlag)
 	}
 
 	if cmd.genDefaultCRFlag != "" {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- aligns the flagname with https://github.com/kyma-project/modulectl/pull/71 and includes a `-c` shortcut

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
