### PR TITLE
chore: Remove Beta and Internal flags with its related dependencies

### DIFF
--- a/cmd/modulectl/create/long.txt
+++ b/cmd/modulectl/create/long.txt
@@ -21,8 +21,6 @@ The module config file is a YAML file used to configure the following attributes
       link:         a URL, required, the link to the icon
 - defaultCR:        a string, optional, reference to a YAML file containing the default CR for the module, must be a URL
 - mandatory:        a boolean, optional, default=false, indicates whether the module is mandatory to be installed on all clusters
-- internal:         a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the internal flag or not
-- beta:             a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the beta flag or not
 - security:         a string, optional, reference to a YAML file containing the security scanners config, must be a local file path
 - labels:           a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
 - annotations:      a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR

--- a/docs/gen-docs/modulectl_create.md
+++ b/docs/gen-docs/modulectl_create.md
@@ -29,8 +29,6 @@ The module config file is a YAML file used to configure the following attributes
       link:         a URL, required, the link to the icon
 - defaultCR:        a string, optional, reference to a YAML file containing the default CR for the module, must be a URL
 - mandatory:        a boolean, optional, default=false, indicates whether the module is mandatory to be installed on all clusters
-- internal:         a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the internal flag or not
-- beta:             a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the beta flag or not
 - security:         a string, optional, reference to a YAML file containing the security scanners config, must be a local file path
 - labels:           a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
 - annotations:      a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR

--- a/internal/service/contentprovider/moduleconfig.go
+++ b/internal/service/contentprovider/moduleconfig.go
@@ -77,8 +77,6 @@ type ModuleConfig struct {
 	DefaultCR           string                     `yaml:"defaultCR" comment:"optional, relative path or remote URL to a YAML file containing the default CR for the module"`
 	Namespace           string                     `yaml:"namespace" comment:"optional, default=kcp-system, the namespace where the ModuleTemplate will be deployed"`
 	Security            string                     `yaml:"security" comment:"optional, name of the security scanners config file"`
-	Internal            bool                       `yaml:"internal" comment:"optional, default=false, determines whether the ModuleTemplate should have the internal flag or not"`
-	Beta                bool                       `yaml:"beta" comment:"optional, default=false, determines whether the ModuleTemplate should have the beta flag or not"`
 	Labels              map[string]string          `yaml:"labels" comment:"optional, additional labels for the ModuleTemplate"`
 	Annotations         map[string]string          `yaml:"annotations" comment:"optional, additional annotations for the ModuleTemplate"`
 	AssociatedResources []*metav1.GroupVersionKind `yaml:"associatedResources" comment:"optional, GVK of the resources which are associated with the module and have to be deleted with module deletion"`

--- a/internal/service/moduleconfig/generator/moduleconfig_generator_test.go
+++ b/internal/service/moduleconfig/generator/moduleconfig_generator_test.go
@@ -125,8 +125,6 @@ func (*fileExistsStub) ReadFile(_ string) ([]byte, error) {
 		DefaultCR:   "path/to/defaultCR",
 		Namespace:   "kcp-system",
 		Security:    "path/to/securityConfig",
-		Internal:    false,
-		Beta:        false,
 		Labels:      map[string]string{"label1": "value1"},
 		Annotations: map[string]string{"annotation1": "value1"},
 		AssociatedResources: []*metav1.GroupVersionKind{

--- a/internal/service/moduleconfig/reader/moduleconfig_reader_test.go
+++ b/internal/service/moduleconfig/reader/moduleconfig_reader_test.go
@@ -42,8 +42,6 @@ func Test_ParseModuleConfig_Returns_CorrectModuleConfig(t *testing.T) {
 	require.False(t, result.Mandatory)
 	require.Equal(t, "kcp-system", result.Namespace)
 	require.Equal(t, "path/to/securityConfig", result.Security)
-	require.False(t, result.Internal)
-	require.False(t, result.Beta)
 	require.Equal(t, map[string]string{"label1": "value1"}, result.Labels)
 	require.Equal(t, map[string]string{"annotation1": "value1"}, result.Annotations)
 	require.Equal(t, "networking.istio.io", result.AssociatedResources[0].Group)
@@ -536,8 +534,6 @@ var expectedReturnedModuleConfig = contentprovider.ModuleConfig{
 	DefaultCR:   "https://example.com/path/to/defaultCR",
 	Namespace:   "kcp-system",
 	Security:    "path/to/securityConfig",
-	Internal:    false,
-	Beta:        false,
 	Labels:      map[string]string{"label1": "value1"},
 	Annotations: map[string]string{"annotation1": "value1"},
 	AssociatedResources: []*metav1.GroupVersionKind{

--- a/internal/service/templategenerator/templategenerator.go
+++ b/internal/service/templategenerator/templategenerator.go
@@ -207,13 +207,6 @@ func generateLabels(config *contentprovider.ModuleConfig) map[string]string {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	if config.Beta {
-		labels[shared.BetaLabel] = shared.EnableLabelValue
-	}
-
-	if config.Internal {
-		labels[shared.InternalLabel] = shared.EnableLabelValue
-	}
 
 	if config.Mandatory {
 		labels[shared.IsMandatoryModule] = shared.EnableLabelValue

--- a/tests/e2e/scaffold/scaffold_suite_test.go
+++ b/tests/e2e/scaffold/scaffold_suite_test.go
@@ -144,8 +144,6 @@ type moduleConfig struct {
 	DefaultCRPath string            `yaml:"defaultCR" comment:"optional, relative path or remote URL to a YAML file containing the default CR for the module"`
 	Namespace     string            `yaml:"namespace" comment:"optional, default=kcp-system, the namespace where the ModuleTemplate will be deployed"`
 	Security      string            `yaml:"security" comment:"optional, name of the security scanners config file"`
-	Internal      bool              `yaml:"internal" comment:"optional, default=false, determines whether the ModuleTemplate should have the internal flag or not"`
-	Beta          bool              `yaml:"beta" comment:"optional, default=false, determines whether the ModuleTemplate should have the beta flag or not"`
 	Labels        map[string]string `yaml:"labels" comment:"optional, additional labels for the ModuleTemplate"`
 	Annotations   map[string]string `yaml:"annotations" comment:"optional, additional annotations for the ModuleTemplate"`
 }


### PR DESCRIPTION

**Description**
Drop and clean `beta` and `internal` label and flags.

Changes proposed in this pull request:

- Removed from ModuleConfig.
- Removed from Template Generator.
- Removed from Command line description.
- Removed from unit tests.
- Remved from e2e Test.

**Related issue(s)**
#117