### PR TITLE
docs: Align docs for ModuleConfig type and Create command help

### DIFF
--- a/cmd/modulectl/create/long.txt
+++ b/cmd/modulectl/create/long.txt
@@ -11,30 +11,31 @@ Provide the `--config-file` flag with a config file path.
 The module config file is a YAML file used to configure the following attributes for the module:
 
 ```yaml
-- name:             a string, required, the name of the module
-- version:          a string, required, the version of the module
-- manifest:         a string, required, reference to the manifest, must be a URL
-- repository:       a string, required, reference to the repository, must be a URL
-- documentation:    a string, required, reference to the documentation, must be a URL
-- icons:            a map with string keys and values, required, icons used for UI
-    - name:         a string, required, the name of the icon
-      link:         a URL, required, the link to the icon
-- defaultCR:        a string, optional, reference to a YAML file containing the default CR for the module, must be a URL
-- mandatory:        a boolean, optional, default=false, indicates whether the module is mandatory to be installed on all clusters
-- security:         a string, optional, reference to a YAML file containing the security scanners config, must be a local file path
-- labels:           a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
-- annotations:      a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
-- manager:          # an object, optional, module resource that indicates the installation readiness of the module
-    name:           a string, required, the name of the module resource
-    namespace:      a string, optional, the namespace of the module resource
-    group:          a string, required, the API group of the module resource
-    version:        a string, required, the API version of the module resource
-    kind:           a string, required, the API kind of the module resource
-- associatedResources: a list of Group-Version-Kind(GVK), optional, resources that should be cleaned up with the module deletion
-- resources:        # a map with string keys and values, optional, additional resources of the module that may be fetched
-    - name:         a string, required, the name of the resource
-      link:         a URL, required, the link to the resource
-- requiresDowntime: a boolean, optional, default=false, indicates whether the module requires downtime to support maintenance windows during module upgrades
+- name:                 a string, required, the name of the module
+- version:              a string, required, the version of the module
+- manifest:             a string, required, reference to the manifest, must be a URL
+- repository:           a string, required, reference to the repository, must be a URL
+- documentation:        a string, required, reference to the documentation, must be a URL
+- icons:                a map with string keys and values, required, icons used for UI
+    - name:             a string, required, the name of the icon
+      link:             a URL, required, the link to the icon
+- defaultCR:            a string, optional, reference to a YAML file containing the default CR for the module, must be a URL
+- mandatory:            a boolean, optional, default=false, indicates whether the module is mandatory to be installed on all clusters
+- security:             a string, optional, reference to a YAML file containing the security scanners config, must be a local file path
+- labels:               a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
+- annotations:          a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
+- manager:              an object, optional, module resource that indicates the installation readiness of the module, typically the manager deployment of the module
+    name:               a string, required, the name of the module resource
+    namespace:          a string, optional, the namespace of the module resource
+    group:              a string, required, the API group of the module resource
+    version:            a string, required, the API version of the module resource
+    kind:               a string, required, the API kind of the module resource
+- associatedResources:  a list of Group-Version-Kind(GVK), optional, resources that should be cleaned up with the module deletion
+- resources:            a map with string keys and values, optional, additional resources of the module that may be fetched
+    - name:             a string, required, the name of the resource
+      link:             a URL, required, the link to the resource
+- requiresDowntime:     a boolean, optional, default=false, indicates whether the module requires downtime to support maintenance windows during module upgrades
+- namespace:            a string, optional, default=kcp-system, the namespace where the ModuleTemplate will be deployed
 ```
 
 The **manifest** file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.

--- a/docs/gen-docs/modulectl_create.md
+++ b/docs/gen-docs/modulectl_create.md
@@ -19,30 +19,31 @@ Provide the `--config-file` flag with a config file path.
 The module config file is a YAML file used to configure the following attributes for the module:
 
 ```yaml
-- name:             a string, required, the name of the module
-- version:          a string, required, the version of the module
-- manifest:         a string, required, reference to the manifest, must be a URL
-- repository:       a string, required, reference to the repository, must be a URL
-- documentation:    a string, required, reference to the documentation, must be a URL
-- icons:            a map with string keys and values, required, icons used for UI
-    - name:         a string, required, the name of the icon
-      link:         a URL, required, the link to the icon
-- defaultCR:        a string, optional, reference to a YAML file containing the default CR for the module, must be a URL
-- mandatory:        a boolean, optional, default=false, indicates whether the module is mandatory to be installed on all clusters
-- security:         a string, optional, reference to a YAML file containing the security scanners config, must be a local file path
-- labels:           a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
-- annotations:      a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
-- manager:          # an object, optional, module resource that indicates the installation readiness of the module
-    name:           a string, required, the name of the module resource
-    namespace:      a string, optional, the namespace of the module resource
-    group:          a string, required, the API group of the module resource
-    version:        a string, required, the API version of the module resource
-    kind:           a string, required, the API kind of the module resource
-- associatedResources: a list of Group-Version-Kind(GVK), optional, resources that should be cleaned up with the module deletion
-- resources:        # a map with string keys and values, optional, additional resources of the module that may be fetched
-    - name:         a string, required, the name of the resource
-      link:         a URL, required, the link to the resource
-- requiresDowntime: a boolean, optional, default=false, indicates whether the module requires downtime to support maintenance windows during module upgrades
+- name:                 a string, required, the name of the module
+- version:              a string, required, the version of the module
+- manifest:             a string, required, reference to the manifest, must be a URL
+- repository:           a string, required, reference to the repository, must be a URL
+- documentation:        a string, required, reference to the documentation, must be a URL
+- icons:                a map with string keys and values, required, icons used for UI
+    - name:             a string, required, the name of the icon
+      link:             a URL, required, the link to the icon
+- defaultCR:            a string, optional, reference to a YAML file containing the default CR for the module, must be a URL
+- mandatory:            a boolean, optional, default=false, indicates whether the module is mandatory to be installed on all clusters
+- security:             a string, optional, reference to a YAML file containing the security scanners config, must be a local file path
+- labels:               a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
+- annotations:          a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
+- manager:              an object, optional, module resource that indicates the installation readiness of the module, typically the manager deployment of the module
+    name:               a string, required, the name of the module resource
+    namespace:          a string, optional, the namespace of the module resource
+    group:              a string, required, the API group of the module resource
+    version:            a string, required, the API version of the module resource
+    kind:               a string, required, the API kind of the module resource
+- associatedResources:  a list of Group-Version-Kind(GVK), optional, resources that should be cleaned up with the module deletion
+- resources:            a map with string keys and values, optional, additional resources of the module that may be fetched
+    - name:             a string, required, the name of the resource
+      link:             a URL, required, the link to the resource
+- requiresDowntime:     a boolean, optional, default=false, indicates whether the module requires downtime to support maintenance windows during module upgrades
+- namespace:            a string, optional, default=kcp-system, the namespace where the ModuleTemplate will be deployed
 ```
 
 The **manifest** file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.

--- a/internal/service/contentprovider/moduleconfig.go
+++ b/internal/service/contentprovider/moduleconfig.go
@@ -67,22 +67,22 @@ func (s *ModuleConfigProvider) validateArgs(args types.KeyValueArgs) error {
 }
 
 type ModuleConfig struct {
-	Name                string                     `yaml:"name" comment:"required, the name of the Module"`
-	Version             string                     `yaml:"version" comment:"required, the version of the Module"`
-	Manifest            string                     `yaml:"manifest" comment:"required, relative path or remote URL to the manifests"`
-	Repository          string                     `yaml:"repository" comment:"required, link to the repository"`
-	Documentation       string                     `yaml:"documentation" comment:"required, link to documentation"`
-	Icons               Icons                      `yaml:"icons,omitempty" comment:"required, list of icons to represent the module in the UI"`
+	Name                string                     `yaml:"name" comment:"required, the name of the module"`
+	Version             string                     `yaml:"version" comment:"required, the version of the module"`
+	Manifest            string                     `yaml:"manifest" comment:"required, reference to the manifest, must be a URL"`
+	Repository          string                     `yaml:"repository" comment:"required, reference to the repository, must be a URL"`
+	Documentation       string                     `yaml:"documentation" comment:"required, reference to the documentation, must be a URL"`
+	Icons               Icons                      `yaml:"icons,omitempty" comment:"required, icons used for UI"`
+	DefaultCR           string                     `yaml:"defaultCR" comment:"optional, reference to a YAML file containing the default CR for the module, must be a URL"`
 	Mandatory           bool                       `yaml:"mandatory" comment:"optional, default=false, indicates whether the module is mandatory to be installed on all clusters"`
-	DefaultCR           string                     `yaml:"defaultCR" comment:"optional, relative path or remote URL to a YAML file containing the default CR for the module"`
-	Namespace           string                     `yaml:"namespace" comment:"optional, default=kcp-system, the namespace where the ModuleTemplate will be deployed"`
-	Security            string                     `yaml:"security" comment:"optional, name of the security scanners config file"`
-	Labels              map[string]string          `yaml:"labels" comment:"optional, additional labels for the ModuleTemplate"`
-	Annotations         map[string]string          `yaml:"annotations" comment:"optional, additional annotations for the ModuleTemplate"`
-	AssociatedResources []*metav1.GroupVersionKind `yaml:"associatedResources" comment:"optional, GVK of the resources which are associated with the module and have to be deleted with module deletion"`
-	Manager             *Manager                   `yaml:"manager" comment:"optional, the module resource that can be used to indicate the installation readiness of the module. This is typically the manager deployment of the module"`
-	Resources           Resources                  `yaml:"resources,omitempty" comment:"optional, additional resources of the ModuleTemplate that may be fetched"`
+	Security            string                     `yaml:"security" comment:"optional, reference to a YAML file containing the security scanners config, must be a local file path"`
+	Labels              map[string]string          `yaml:"labels" comment:"values, optional, additional labels for the generated ModuleTemplate CR"`
+	Annotations         map[string]string          `yaml:"annotations" comment:"optional, additional annotations for the generated ModuleTemplate CR"`
+	Manager             *Manager                   `yaml:"manager" comment:"optional, module resource that indicates the installation readiness of the module, typically the manager deployment of the module"`
+	AssociatedResources []*metav1.GroupVersionKind `yaml:"associatedResources" comment:"optional, optional, resources that should be cleaned up with the module deletion"`
+	Resources           Resources                  `yaml:"resources,omitempty" comment:"optional, additional resources of the module that may be fetched"`
 	RequiresDowntime    bool                       `yaml:"requiresDowntime" comment:"optional, default=false, indicates whether the module requires downtime to support maintenance windows during module upgrades"`
+	Namespace           string                     `yaml:"namespace" comment:"optional, default=kcp-system, the namespace where the ModuleTemplate will be deployed"`
 }
 
 type Manager struct {

--- a/internal/service/contentprovider/moduleconfig.go
+++ b/internal/service/contentprovider/moduleconfig.go
@@ -76,7 +76,7 @@ type ModuleConfig struct {
 	DefaultCR           string                     `yaml:"defaultCR" comment:"optional, reference to a YAML file containing the default CR for the module, must be a URL"`
 	Mandatory           bool                       `yaml:"mandatory" comment:"optional, default=false, indicates whether the module is mandatory to be installed on all clusters"`
 	Security            string                     `yaml:"security" comment:"optional, reference to a YAML file containing the security scanners config, must be a local file path"`
-	Labels              map[string]string          `yaml:"labels" comment:"values, optional, additional labels for the generated ModuleTemplate CR"`
+	Labels              map[string]string          `yaml:"labels" comment:"optional, additional labels for the generated ModuleTemplate CR"`
 	Annotations         map[string]string          `yaml:"annotations" comment:"optional, additional annotations for the generated ModuleTemplate CR"`
 	Manager             *Manager                   `yaml:"manager" comment:"optional, module resource that indicates the installation readiness of the module, typically the manager deployment of the module"`
 	AssociatedResources []*metav1.GroupVersionKind `yaml:"associatedResources" comment:"optional, optional, resources that should be cleaned up with the module deletion"`


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- there we slight inconsistencies between the ModuleConfig struct and the Create command help where this config is used. This PR tries to align them.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
