### PR TITLE
feat: Introduce `--dry-run` flag

### DIFF
--- a/cmd/modulectl/create/flags.go
+++ b/cmd/modulectl/create/flags.go
@@ -39,20 +39,46 @@ const (
 	OverwriteComponentVersionFlagName    = "overwrite"
 	overwriteComponentVersionFlagUsage   = "Overwrites the pushed component version if it already exists in the OCI registry. Use the flag ONLY for testing purposes."
 	OverwriteComponentVersionFlagDefault = false
+
+	DryRunFlagName    = "dry-run"
+	dryRunFlagUsage   = "Skips the push of the module descriptor to the registry."
+	DryRunFlagDefault = false
 )
 
 func parseFlags(flags *pflag.FlagSet, opts *create.Options) {
-	flags.StringVarP(&opts.ConfigFile, ConfigFileFlagName, configFileFlagShort, ConfigFileFlagDefault,
+	flags.StringVarP(&opts.ConfigFile,
+		ConfigFileFlagName,
+		configFileFlagShort,
+		ConfigFileFlagDefault,
 		configFileFlagUsage)
-	flags.StringVar(&opts.Credentials, CredentialsFlagName, CredentialsFlagDefault,
+	flags.StringVar(&opts.Credentials,
+		CredentialsFlagName,
+		CredentialsFlagDefault,
 		credentialsFlagUsage)
-	flags.BoolVar(&opts.Insecure, InsecureFlagName, InsecureFlagDefault, insecureFlagUsage)
-	flags.StringVarP(&opts.TemplateOutput, TemplateOutputFlagName, templateOutputFlagShort, TemplateOutputFlagDefault,
+	flags.BoolVar(&opts.Insecure,
+		InsecureFlagName,
+		InsecureFlagDefault,
+		insecureFlagUsage)
+	flags.StringVarP(&opts.TemplateOutput,
+		TemplateOutputFlagName,
+		templateOutputFlagShort,
+		TemplateOutputFlagDefault,
 		templateOutputFlagUsage)
-	flags.StringVarP(&opts.RegistryURL, RegistryURLFlagName, registryFlagShort, RegistryURLFlagDefault,
+	flags.StringVarP(&opts.RegistryURL,
+		RegistryURLFlagName,
+		registryFlagShort,
+		RegistryURLFlagDefault,
 		registryURLFlagUsage)
-	flags.StringVar(&opts.RegistryCredSelector, RegistryCredSelectorFlagName, RegistryCredSelectorFlagDefault,
+	flags.StringVar(&opts.RegistryCredSelector,
+		RegistryCredSelectorFlagName,
+		RegistryCredSelectorFlagDefault,
 		registryCredSelectorFlagUsage)
-	flags.BoolVar(&opts.OverwriteComponentVersion, OverwriteComponentVersionFlagName,
-		OverwriteComponentVersionFlagDefault, overwriteComponentVersionFlagUsage)
+	flags.BoolVar(&opts.OverwriteComponentVersion,
+		OverwriteComponentVersionFlagName,
+		OverwriteComponentVersionFlagDefault,
+		overwriteComponentVersionFlagUsage)
+	flags.BoolVar(&opts.DryRun,
+		DryRunFlagName,
+		DryRunFlagDefault,
+		dryRunFlagUsage)
 }

--- a/cmd/modulectl/create/flags_test.go
+++ b/cmd/modulectl/create/flags_test.go
@@ -7,7 +7,7 @@ import (
 	createcmd "github.com/kyma-project/modulectl/cmd/modulectl/create"
 )
 
-func Test_ScaffoldFlagsDefaults(t *testing.T) {
+func Test_CreateFlagsDefaults(t *testing.T) {
 	tests := []struct {
 		name     string
 		value    string
@@ -23,6 +23,8 @@ func Test_ScaffoldFlagsDefaults(t *testing.T) {
 		{name: createcmd.TemplateOutputFlagName, value: createcmd.TemplateOutputFlagDefault, expected: "template.yaml"},
 		{name: createcmd.RegistryURLFlagName, value: createcmd.RegistryURLFlagDefault, expected: ""},
 		{name: createcmd.RegistryCredSelectorFlagName, value: createcmd.RegistryCredSelectorFlagDefault, expected: ""},
+		{name: createcmd.OverwriteComponentVersionFlagName, value: strconv.FormatBool(createcmd.OverwriteComponentVersionFlagDefault), expected: "false"},
+		{name: createcmd.DryRunFlagName, value: strconv.FormatBool(createcmd.DryRunFlagDefault), expected: "false"},
 	}
 
 	for _, testcase := range tests {

--- a/docs/gen-docs/modulectl_create.md
+++ b/docs/gen-docs/modulectl_create.md
@@ -73,6 +73,7 @@ Build a simple module and push it to a remote registry
 
 ```bash
 -c, --config-file string              Specifies the path to the module configuration file.
+    --dry-run                         Skips the push of the module descriptor to the registry.
 -h, --help                            Provides help for the create command.
     --insecure                        Uses an insecure connection to access the registry.
 -o, --output string                   Path to write the ModuleTemplate file to, if the module is uploaded to a registry (default "template.yaml").

--- a/internal/service/create/create.go
+++ b/internal/service/create/create.go
@@ -205,12 +205,14 @@ func (s *Service) Run(opts Options) error {
 		return fmt.Errorf("failed to add module resources to component archive: %w", err)
 	}
 
-	if opts.RegistryURL != "" {
-		opts.Out.Write("- Pushing component version\n")
+	opts.Out.Write("- Pushing component version\n")
+	if !opts.DryRun && opts.RegistryURL != "" {
 		descriptor, err = s.pushComponentVersion(archive, opts)
 		if err != nil {
 			return fmt.Errorf("failed to push component version: %w", err)
 		}
+	} else {
+		opts.Out.Write("\t\tSkipping due to dry-run mode\n")
 	}
 
 	if opts.RegistryURL != "" {

--- a/internal/service/create/create.go
+++ b/internal/service/create/create.go
@@ -205,19 +205,23 @@ func (s *Service) Run(opts Options) error {
 		return fmt.Errorf("failed to add module resources to component archive: %w", err)
 	}
 
-	opts.Out.Write("- Pushing component version\n")
-	descriptor, err = s.pushComponentVersion(archive, opts)
-	if err != nil {
-		return fmt.Errorf("failed to push component version: %w", err)
+	if opts.RegistryURL != "" {
+		opts.Out.Write("- Pushing component version\n")
+		descriptor, err = s.pushComponentVersion(archive, opts)
+		if err != nil {
+			return fmt.Errorf("failed to push component version: %w", err)
+		}
 	}
 
-	opts.Out.Write("- Generating ModuleTemplate\n")
-	if err = s.generateModuleTemplate(moduleConfig,
-		descriptor,
-		manifestFilePath,
-		defaultCRFilePath,
-		opts.TemplateOutput); err != nil {
-		return fmt.Errorf("failed to generate module template: %w", err)
+	if opts.RegistryURL != "" {
+		opts.Out.Write("- Generating ModuleTemplate\n")
+		if err = s.generateModuleTemplate(moduleConfig,
+			descriptor,
+			manifestFilePath,
+			defaultCRFilePath,
+			opts.TemplateOutput); err != nil {
+			return fmt.Errorf("failed to generate module template: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/service/create/create.go
+++ b/internal/service/create/create.go
@@ -206,7 +206,7 @@ func (s *Service) Run(opts Options) error {
 	}
 
 	opts.Out.Write("- Pushing component version\n")
-	if !opts.DryRun && opts.RegistryURL != "" {
+	if !opts.DryRun {
 		descriptor, err = s.pushComponentVersion(archive, opts)
 		if err != nil {
 			return fmt.Errorf("failed to push component version: %w", err)
@@ -215,15 +215,13 @@ func (s *Service) Run(opts Options) error {
 		opts.Out.Write("\t\tSkipping due to dry-run mode\n")
 	}
 
-	if opts.RegistryURL != "" {
-		opts.Out.Write("- Generating ModuleTemplate\n")
-		if err = s.generateModuleTemplate(moduleConfig,
-			descriptor,
-			manifestFilePath,
-			defaultCRFilePath,
-			opts.TemplateOutput); err != nil {
-			return fmt.Errorf("failed to generate module template: %w", err)
-		}
+	opts.Out.Write("- Generating ModuleTemplate\n")
+	if err = s.generateModuleTemplate(moduleConfig,
+		descriptor,
+		manifestFilePath,
+		defaultCRFilePath,
+		opts.TemplateOutput); err != nil {
+		return fmt.Errorf("failed to generate module template: %w", err)
 	}
 
 	return nil

--- a/internal/service/create/create.go
+++ b/internal/service/create/create.go
@@ -140,6 +140,7 @@ func NewService(moduleConfigService ModuleConfigService,
 	}, nil
 }
 
+//nolint:funlen // this is a straight down aggregation of the individual steps
 func (s *Service) Run(opts Options) error {
 	if err := opts.Validate(); err != nil {
 		return err

--- a/internal/service/create/options.go
+++ b/internal/service/create/options.go
@@ -18,6 +18,7 @@ type Options struct {
 	RegistryURL               string
 	RegistryCredSelector      string
 	OverwriteComponentVersion bool
+	DryRun                    bool
 }
 
 func (opts Options) Validate() error {
@@ -48,6 +49,10 @@ func (opts Options) Validate() error {
 
 	if opts.OverwriteComponentVersion {
 		opts.Out.Write("Warning: overwrite flag is set to true. This should ONLY be used for testing purposes.\n")
+	}
+
+	if opts.DryRun {
+		opts.Out.Write("Warning: dry-run flag is set to true. The descriptor will NOT be pushed.\n")
 	}
 
 	return nil

--- a/internal/service/create/options.go
+++ b/internal/service/create/options.go
@@ -43,7 +43,11 @@ func (opts Options) Validate() error {
 		return fmt.Errorf("opts.TemplateOutput must not be empty: %w", commonerrors.ErrInvalidOption)
 	}
 
-	if opts.RegistryURL != "" && !strings.HasPrefix(opts.RegistryURL, "http") {
+	if opts.RegistryURL == "" {
+		return fmt.Errorf("opts.RegistryURL must not be empty: %w", commonerrors.ErrInvalidOption)
+	}
+
+	if !strings.HasPrefix(opts.RegistryURL, "http") {
 		return fmt.Errorf("opts.RegistryURL does not start with http(s): %w", commonerrors.ErrInvalidOption)
 	}
 

--- a/internal/service/create/options_test.go
+++ b/internal/service/create/options_test.go
@@ -67,6 +67,18 @@ func Test_Validate_Options(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "RegistryURL is empty",
+			options: create.Options{
+				Out:            iotools.NewDefaultOut(io.Discard),
+				ConfigFile:     "config.yaml",
+				Credentials:    "username:password",
+				TemplateOutput: "output",
+				RegistryURL:    "",
+			},
+			wantErr: true,
+			errMsg:  "opts.RegistryURL must not be empty",
+		},
+		{
 			name: "RegistryURL does not start with http",
 			options: create.Options{
 				Out:            iotools.NewDefaultOut(io.Discard),

--- a/internal/service/templategenerator/templategenerator.go
+++ b/internal/service/templategenerator/templategenerator.go
@@ -136,6 +136,9 @@ func (s *Service) GenerateModuleTemplate(
 	if moduleConfig == nil {
 		return ErrEmptyModuleConfig
 	}
+	if descriptor == nil {
+		return ErrEmptyDescriptor
+	}
 
 	labels := generateLabels(moduleConfig)
 	annotations := generateAnnotations(moduleConfig, isCrdClusterScoped)
@@ -156,12 +159,9 @@ func (s *Service) GenerateModuleTemplate(
 		return fmt.Errorf("failed to parse module template: %w", err)
 	}
 
-	var cva compdesc.ComponentDescriptorVersion = nil
-	if descriptor != nil {
-		cva, err = compdesc.Convert(descriptor)
-		if err != nil {
-			return fmt.Errorf("failed to convert descriptor: %w", err)
-		}
+	cva, err := compdesc.Convert(descriptor)
+	if err != nil {
+		return fmt.Errorf("failed to convert descriptor: %w", err)
 	}
 
 	mtData := moduleTemplateData{

--- a/internal/service/templategenerator/templategenerator.go
+++ b/internal/service/templategenerator/templategenerator.go
@@ -136,9 +136,6 @@ func (s *Service) GenerateModuleTemplate(
 	if moduleConfig == nil {
 		return ErrEmptyModuleConfig
 	}
-	if descriptor == nil {
-		return ErrEmptyDescriptor
-	}
 
 	labels := generateLabels(moduleConfig)
 	annotations := generateAnnotations(moduleConfig, isCrdClusterScoped)
@@ -159,9 +156,12 @@ func (s *Service) GenerateModuleTemplate(
 		return fmt.Errorf("failed to parse module template: %w", err)
 	}
 
-	cva, err := compdesc.Convert(descriptor)
-	if err != nil {
-		return fmt.Errorf("failed to convert descriptor: %w", err)
+	var cva compdesc.ComponentDescriptorVersion = nil
+	if descriptor != nil {
+		cva, err = compdesc.Convert(descriptor)
+		if err != nil {
+			return fmt.Errorf("failed to convert descriptor: %w", err)
+		}
 	}
 
 	mtData := moduleTemplateData{

--- a/internal/service/templategenerator/templategenerator.go
+++ b/internal/service/templategenerator/templategenerator.go
@@ -143,7 +143,7 @@ func (s *Service) GenerateModuleTemplate(
 	labels := generateLabels(moduleConfig)
 	annotations := generateAnnotations(moduleConfig, isCrdClusterScoped)
 
-	ref, err := oci.ParseRef(descriptor.Name)
+	ref, err := oci.ParseRef(moduleConfig.Name)
 	if err != nil {
 		return fmt.Errorf("failed to parse ref: %w", err)
 	}

--- a/internal/service/templategenerator/templategenerator_test.go
+++ b/internal/service/templategenerator/templategenerator_test.go
@@ -14,6 +14,14 @@ import (
 	_ "ocm.software/ocm/api/ocm/compdesc/versions/v2"
 )
 
+var defaultData = []byte(`apiVersion: operator.kyma-project.io/v1alpha1
+kind: Sample
+metadata:
+  name: sample-yaml
+spec:
+  resourceFilePath: "./module-data.yaml"
+`)
+
 func TestNew_WhenCalledWithNilDependencies_ReturnsError(t *testing.T) {
 	_, err := templategenerator.NewService(nil)
 
@@ -29,24 +37,30 @@ func TestGenerateModuleTemplate_WhenCalledWithNilConfig_ReturnsError(t *testing.
 	require.ErrorIs(t, err, templategenerator.ErrEmptyModuleConfig)
 }
 
-func TestGenerateModuleTemplate_WhenCalledWithNilDescriptor_ReturnsError(t *testing.T) {
-	svc, _ := templategenerator.NewService(&mockFileSystem{})
+func TestGenerateModuleTemplate_WhenCalledWithNilDescriptor(t *testing.T) {
+	moduleConfig := &contentprovider.ModuleConfig{
+		Name:        "example.com/component",
+		Namespace:   "default",
+		Version:     "1.0.0",
+		Labels:      map[string]string{"key": "value"},
+		Annotations: map[string]string{"annotation": "value"},
+		Mandatory:   true,
+		Manifest:    "https://github.com/kyma-project/template-operator/releases/download/1.0.1/template-operator.yaml",
+		Resources:   contentprovider.Resources{"someResource": "https://some.other/location/template-operator.yaml"},
+	}
 
-	err := svc.GenerateModuleTemplate(&contentprovider.ModuleConfig{}, nil, nil, false, "")
+	mockFS := &mockFileSystem{}
+	svc, _ := templategenerator.NewService(mockFS)
 
-	require.Error(t, err)
-	require.ErrorIs(t, err, templategenerator.ErrEmptyDescriptor)
+	err := svc.GenerateModuleTemplate(moduleConfig, nil, defaultData, true, "output.yaml")
+
+	require.NoError(t, err)
+
+	assertCommonTemplateProperties(t, mockFS)
+	require.Contains(t, mockFS.writtenTemplate, "descriptor:\n    null")
 }
 
 func TestGenerateModuleTemplate_Success(t *testing.T) {
-	defaultData := []byte(`apiVersion: operator.kyma-project.io/v1alpha1
-kind: Sample
-metadata:
-  name: sample-yaml
-spec:
-  resourceFilePath: "./module-data.yaml"
-`)
-
 	tests := []struct {
 		name         string
 		data         []byte
@@ -312,6 +326,7 @@ spec:
 			require.NoError(t, err)
 			require.Equal(t, "output.yaml", mockFS.path)
 			tt.assertions(t, mockFS)
+			require.Contains(t, mockFS.writtenTemplate, "example.com/component")
 		})
 	}
 }
@@ -332,7 +347,6 @@ func assertCommonTemplateProperties(t *testing.T, mockFS *mockFileSystem) {
 	require.Contains(t, mockFS.writtenTemplate, "moduleName: component")
 	require.Contains(t, mockFS.writtenTemplate, "component-1.0.0")
 	require.Contains(t, mockFS.writtenTemplate, "default")
-	require.Contains(t, mockFS.writtenTemplate, "example.com/component")
 	require.Contains(t, mockFS.writtenTemplate, "rawManifest")
 	require.NotContains(t, mockFS.writtenTemplate, "---")
 	require.Contains(t, mockFS.writtenTemplate, "apiVersion: operator.kyma-project.io/v1alpha1")

--- a/internal/service/templategenerator/templategenerator_test.go
+++ b/internal/service/templategenerator/templategenerator_test.go
@@ -57,6 +57,7 @@ spec:
 			name: "With Resources",
 			data: defaultData,
 			moduleConfig: &contentprovider.ModuleConfig{
+				Name:        "example.com/component",
 				Namespace:   "default",
 				Version:     "1.0.0",
 				Labels:      map[string]string{"key": "value"},
@@ -87,6 +88,7 @@ spec:
    resourceFilePath: "./module-data.yaml"
 `),
 			moduleConfig: &contentprovider.ModuleConfig{
+				Name:        "example.com/component",
 				Namespace:   "default",
 				Version:     "1.0.0",
 				Labels:      map[string]string{"key": "value"},
@@ -103,6 +105,7 @@ spec:
 			name: "With Overwritten Raw Manifest",
 			data: defaultData,
 			moduleConfig: &contentprovider.ModuleConfig{
+				Name:      "example.com/component",
 				Manifest:  "https://github.com/kyma-project/template-operator/releases/download/1.0.1/template-operator.yaml",
 				Resources: contentprovider.Resources{"rawManifest": "https://some.other/location/template-operator.yaml"},
 			},
@@ -117,6 +120,7 @@ spec:
 			name: "With Associated Resources",
 			data: defaultData,
 			moduleConfig: &contentprovider.ModuleConfig{
+				Name:        "example.com/component",
 				Namespace:   "default",
 				Version:     "1.0.0",
 				Labels:      map[string]string{"key": "value"},
@@ -143,6 +147,7 @@ spec:
 			name: "With Manager",
 			data: defaultData,
 			moduleConfig: &contentprovider.ModuleConfig{
+				Name:        "example.com/component",
 				Namespace:   "default",
 				Version:     "1.0.0",
 				Labels:      map[string]string{"key": "value"},
@@ -173,6 +178,7 @@ spec:
 			name: "With Manager Without Namespace",
 			data: defaultData,
 			moduleConfig: &contentprovider.ModuleConfig{
+				Name:        "example.com/component",
 				Namespace:   "default",
 				Version:     "1.0.0",
 				Labels:      map[string]string{"key": "value"},
@@ -201,6 +207,7 @@ spec:
 			name: "With Mandatory False",
 			data: defaultData,
 			moduleConfig: &contentprovider.ModuleConfig{
+				Name:        "example.com/component",
 				Namespace:   "default",
 				Version:     "1.0.0",
 				Labels:      map[string]string{"key": "value"},
@@ -220,6 +227,7 @@ spec:
 			name: "With Mandatory True",
 			data: defaultData,
 			moduleConfig: &contentprovider.ModuleConfig{
+				Name:        "example.com/component",
 				Namespace:   "default",
 				Version:     "1.0.0",
 				Labels:      map[string]string{"key": "value"},
@@ -240,6 +248,7 @@ spec:
 			name: "With Requires Downtime True",
 			data: defaultData,
 			moduleConfig: &contentprovider.ModuleConfig{
+				Name:             "example.com/component",
 				Namespace:        "default",
 				Version:          "1.0.0",
 				Labels:           map[string]string{"key": "value"},
@@ -258,6 +267,7 @@ spec:
 			name: "With Requires Downtime False",
 			data: defaultData,
 			moduleConfig: &contentprovider.ModuleConfig{
+				Name:             "example.com/component",
 				Namespace:        "default",
 				Version:          "1.0.0",
 				Labels:           map[string]string{"key": "value"},
@@ -276,6 +286,7 @@ spec:
 			name: "With No Default CR",
 			data: nil,
 			moduleConfig: &contentprovider.ModuleConfig{
+				Name:        "example.com/component",
 				Namespace:   "default",
 				Version:     "1.0.0",
 				Labels:      map[string]string{"key": "value"},

--- a/tests/e2e/create/create_suite_test.go
+++ b/tests/e2e/create/create_suite_test.go
@@ -65,6 +65,7 @@ type createCmd struct {
 	moduleConfigFile string
 	insecure         bool
 	overwrite        bool
+	dryRun           bool
 }
 
 func (cmd *createCmd) execute() error {
@@ -90,6 +91,10 @@ func (cmd *createCmd) execute() error {
 
 	if cmd.overwrite {
 		args = append(args, "--overwrite")
+	}
+
+	if cmd.dryRun {
+		args = append(args, "--dry-run")
 	}
 
 	println(" >>> Executing command: modulectl", strings.Join(args, " "))

--- a/tests/e2e/create/create_test.go
+++ b/tests/e2e/create/create_test.go
@@ -26,8 +26,10 @@ import (
 var _ = Describe("Test 'create' command", Ordered, func() {
 	Context("Given 'modulectl create' command", func() {
 		var cmd createCmd
-		It("When invoked without any args", func() {
-			cmd = createCmd{}
+		It("When invoked without config-file arg", func() {
+			cmd = createCmd{
+				registry: ociRegistry,
+			}
 		})
 
 		It("Then the command should fail", func() {
@@ -39,8 +41,24 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 
 	Context("Given 'modulectl create' command", func() {
 		var cmd createCmd
+		It("When invoked without registry arg", func() {
+			cmd = createCmd{
+				moduleConfigFile: minimalConfig,
+			}
+		})
+
+		It("Then the command should fail", func() {
+			err := cmd.execute()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("opts.RegistryURL must not be empty: invalid Option"))
+		})
+	})
+
+	Context("Given 'modulectl create' command", func() {
+		var cmd createCmd
 		It("When invoked with missing name", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: missingNameConfig,
 			}
 		})
@@ -55,6 +73,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with missing version", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: missingVersionConfig,
 			}
 		})
@@ -69,6 +88,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with missing manifest", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: missingManifestConfig,
 			}
 		})
@@ -83,6 +103,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with missing repository", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: missingRepositoryConfig,
 			}
 		})
@@ -97,6 +118,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with missing documentation", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: missingDocumentationConfig,
 			}
 		})
@@ -111,6 +133,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with non https repository", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: nonHttpsRepository,
 			}
 		})
@@ -125,6 +148,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with non https documentation", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: nonHttpsDocumentation,
 			}
 		})
@@ -139,6 +163,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with missing icons", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: missingIconsConfig,
 			}
 		})
@@ -153,6 +178,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with duplicate entry in icons", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: duplicateIcons,
 			}
 		})
@@ -167,6 +193,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with invalid icon - link missing", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: iconsWithoutLink,
 			}
 		})
@@ -181,6 +208,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with invalid icon - name missing", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: iconsWithoutName,
 			}
 		})
@@ -195,6 +223,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with duplicate entry in resources", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: duplicateResources,
 			}
 		})
@@ -209,6 +238,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with non https resource", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: nonHttpsResource,
 			}
 		})
@@ -223,6 +253,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with invalid resource - link missing", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: resourceWithoutLink,
 			}
 		})
@@ -237,6 +268,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with invalid resource - name missing", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: resourceWithoutName,
 			}
 		})
@@ -244,23 +276,6 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 			err := cmd.execute()
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("failed to parse module config: failed to validate module config: failed to validate resources: name must not be empty: invalid Option"))
-		})
-	})
-
-	Context("Given 'modulectl create' command", func() {
-		var cmd createCmd
-		It("When invoked with '--config-file' using valid file", func() {
-			cmd = createCmd{
-				moduleConfigFile: minimalConfig,
-			}
-		})
-		It("Then the command should succeed", func() {
-			Expect(cmd.execute()).To(Succeed())
-
-			By("And no module template file should be generated")
-			currentDir, err := os.Getwd()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(filesIn(currentDir)).Should(Not(ContainElement("template.yaml")))
 		})
 	})
 
@@ -786,6 +801,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with manifest being a fileref", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: manifestFileref,
 			}
 		})
@@ -800,6 +816,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 		var cmd createCmd
 		It("When invoked with default CR being a fileref", func() {
 			cmd = createCmd{
+				registry:         ociRegistry,
 				moduleConfigFile: defaultCRFileref,
 			}
 		})

--- a/unit-test-coverage.yaml
+++ b/unit-test-coverage.yaml
@@ -9,7 +9,7 @@ packages:
   internal/service/fileresolver: 100
   internal/service/moduleconfig/generator: 100
   internal/service/moduleconfig/reader: 76
-  internal/service/create: 42.3
+  internal/service/create: 41.7
   internal/service/componentdescriptor: 80
   internal/service/templategenerator: 85
   internal/service/crdparser: 73


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- refactored `create.go` to separate pushing the descriptor from writing the module template
- introduces the `--dry-run` flag
  - when set, the descriptor is NOT pushed to the registry
  - the ModuleTemplate is still written (written descriptor is the one that would have been pushing. Misses some info available only after pushing)
- made the `--registry` flag required
  - removed the implicit behavior of NOT pushing and NOT writing the module template if `--registry` is empty
  - this is replaced by the explicit `--dry-run` flag
- does NOT implement the `Clarify if we need to implement OCI artifact push check (no conflicts present)` part
  - if we need to implement this, it will be introduced via separate PR

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- closes: https://github.com/kyma-project/modulectl/issues/119
