### PR TITLE
fix: Create test e2e files not asserted correctly

### DIFF
--- a/tests/e2e/create/create_test.go
+++ b/tests/e2e/create/create_test.go
@@ -398,7 +398,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 				moduleConfigFile: minimalConfig,
 				registry:         ociRegistry,
 				insecure:         true,
-				output:           templateOutputPath,
+				output:           "/tmp/template-2-yaml",
 				dryRun:           true,
 			}
 		})
@@ -407,9 +407,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 			Expect(err.Error()).Should(ContainSubstring("component kyma-project.io/module/template-operator in version 1.0.0 already exists: component version already exists"))
 
 			By("And no module template file should be generated")
-			currentDir, err := os.Getwd()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(filesIn(currentDir)).Should(Not(ContainElement("template.yaml")))
+			Expect(filesIn("/tmp/")).Should(Not(ContainElement("template-2.yaml")))
 		})
 	})
 
@@ -454,6 +452,7 @@ var _ = Describe("Test 'create' command", Ordered, func() {
 				registry:         ociRegistry,
 				insecure:         true,
 				overwrite:        true,
+				output:           templateOutputPath,
 			}
 		})
 		It("Then the command should succeed", func() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- small follow-up fix for #119 
- files were not asserted correctly and one file was written to wrong folder

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
