### PR TITLE
chore: Rename 'protecode' to 'bdba'

### DIFF
--- a/internal/service/componentdescriptor/securityconfig.go
+++ b/internal/service/componentdescriptor/securityconfig.go
@@ -90,8 +90,8 @@ func (s *SecurityConfigService) AppendSecurityScanConfig(descriptor *compdesc.Co
 		return fmt.Errorf("failed to append security labels to sources: %w", err)
 	}
 
-	if err := AppendProtecodeImagesLayers(descriptor, securityConfig); err != nil {
-		return fmt.Errorf("failed to append protecode images layers: %w", err)
+	if err := AppendBDBAImagesLayers(descriptor, securityConfig); err != nil {
+		return fmt.Errorf("failed to append bdba images layers: %w", err)
 	}
 
 	return nil
@@ -132,11 +132,11 @@ func AppendSecurityLabelsToSources(securityScanConfig contentprovider.SecuritySc
 	return nil
 }
 
-func AppendProtecodeImagesLayers(componentDescriptor *compdesc.ComponentDescriptor,
+func AppendBDBAImagesLayers(componentDescriptor *compdesc.ComponentDescriptor,
 	securityScanConfig contentprovider.SecurityScanConfig,
 ) error {
-	protecodeImages := securityScanConfig.Protecode
-	for _, img := range protecodeImages {
+	imagesToScan := securityScanConfig.BDBA
+	for _, img := range imagesToScan {
 		imgName, imgTag, err := utils.GetImageNameAndTag(img)
 		if err != nil {
 			return fmt.Errorf("failed to get image name and tag: %w", err)

--- a/internal/service/componentdescriptor/securityconfig_test.go
+++ b/internal/service/componentdescriptor/securityconfig_test.go
@@ -20,20 +20,20 @@ func Test_NewSecurityConfigService_ReturnsErrorOnNilFileReader(t *testing.T) {
 	require.Nil(t, securityConfigService)
 }
 
-func Test_AppendProtecodeImagesLayers_ReturnCorrectResources(t *testing.T) {
+func Test_AppendBDBAImagesLayers_ReturnCorrectResources(t *testing.T) {
 	cd := &compdesc.ComponentDescriptor{}
 	cd.SetName("test.io/module/test")
 	cd.SetVersion("1.0.0")
 	cd.Provider = ocmv1.Provider{Name: "kyma"}
 
 	securityConfig := contentprovider.SecurityScanConfig{
-		Protecode: []string{
+		BDBA: []string{
 			"europe-docker.pkg.dev/kyma-project/prod/template-operator:1.0.0",
 			"europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/mymodule/anotherimage:4.5.6",
 		},
 	}
 
-	err := componentdescriptor.AppendProtecodeImagesLayers(cd, securityConfig)
+	err := componentdescriptor.AppendBDBAImagesLayers(cd, securityConfig)
 	require.NoError(t, err)
 
 	require.Equal(t, "template-operator", cd.Resources[0].Name)

--- a/internal/service/contentprovider/securityconfig.go
+++ b/internal/service/contentprovider/securityconfig.go
@@ -52,7 +52,7 @@ func (s *SecurityConfig) validateArgs(args types.KeyValueArgs) error {
 func (s *SecurityConfig) getSecurityConfig(moduleName string) SecurityScanConfig {
 	return SecurityScanConfig{
 		ModuleName: moduleName,
-		Protecode: []string{
+		BDBA: []string{
 			"europe-docker.pkg.dev/kyma-project/prod/myimage:1.2.3",
 			"europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/mymodule/anotherimage:4.5.6",
 		},
@@ -64,22 +64,22 @@ func (s *SecurityConfig) getSecurityConfig(moduleName string) SecurityScanConfig
 
 type SecurityScanConfig struct {
 	ModuleName  string               `json:"module-name" yaml:"module-name" comment:"string, name of your module"`
-	Protecode   []string             `json:"protecode" yaml:"protecode" comment:"list, includes the images which must be scanned by the Protecode scanner (aka. Black Duck Binary Analysis)"`
+	BDBA        []string             `json:"bdba" yaml:"bdba" comment:"list, includes the images which must be scanned by the Black Duck Binary Analysis"`
 	WhiteSource WhiteSourceSecConfig `json:"whitesource" yaml:"whitesource" comment:"whitesource (aka. Mend) security scanner specific configuration"`
 	DevBranch   string               `json:"dev-branch" yaml:"dev-branch" comment:"string, name of the development branch"`
 	RcTag       string               `json:"rc-tag" yaml:"rc-tag" comment:"string, release candidate tag"`
 }
 
 func (s *SecurityScanConfig) Validate() error {
-	if err := s.ValidateProtecodeImageTags(); err != nil {
-		return fmt.Errorf("failed to validate protecode image tags: %w", err)
+	if err := s.ValidateBDBAImageTags(); err != nil {
+		return fmt.Errorf("failed to validate bdba image tags: %w", err)
 	}
 	return nil
 }
 
-func (s *SecurityScanConfig) ValidateProtecodeImageTags() error {
-	filteredImages := make([]string, 0, len(s.Protecode))
-	for _, image := range s.Protecode {
+func (s *SecurityScanConfig) ValidateBDBAImageTags() error {
+	filteredImages := make([]string, 0, len(s.BDBA))
+	for _, image := range s.BDBA {
 		_, tag, err := utils.GetImageNameAndTag(image)
 		if err != nil {
 			return fmt.Errorf("failed to get image name and tag: %w", err)
@@ -93,7 +93,7 @@ func (s *SecurityScanConfig) ValidateProtecodeImageTags() error {
 		}
 		filteredImages = append(filteredImages, image)
 	}
-	s.Protecode = filteredImages
+	s.BDBA = filteredImages
 	return nil
 }
 

--- a/internal/service/contentprovider/securityconfig_test.go
+++ b/internal/service/contentprovider/securityconfig_test.go
@@ -58,48 +58,48 @@ func Test_SecurityConfig_GetDefaultContent_ReturnsConvertedContent(t *testing.T)
 	assert.Equal(t, convertedContent, result)
 }
 
-func Test_SecurityScanConfig_ValidateProtecodeImageTags_IgnoresLatestTag(t *testing.T) {
+func Test_SecurityScanConfig_ValidateBDBAImageTags_IgnoresLatestTag(t *testing.T) {
 	config := contentprovider.SecurityScanConfig{
-		Protecode: []string{
+		BDBA: []string{
 			"europe-docker.pkg.dev/kyma-project/dev/test-image:1.2.3",
 			"europe-docker.pkg.dev/kyma-project/dev/test-image:latest",
 		},
 	}
 
-	err := config.ValidateProtecodeImageTags()
+	err := config.ValidateBDBAImageTags()
 
 	require.NoError(t, err)
-	assert.Len(t, config.Protecode, 1)
-	assert.Equal(t, "europe-docker.pkg.dev/kyma-project/dev/test-image:1.2.3", config.Protecode[0])
+	assert.Len(t, config.BDBA, 1)
+	assert.Equal(t, "europe-docker.pkg.dev/kyma-project/dev/test-image:1.2.3", config.BDBA[0])
 }
 
-func Test_SecurityScanConfig_ValidateProtecodeImageTags_ReturnsError_WhenNonSemVerTag(t *testing.T) {
+func Test_SecurityScanConfig_ValidateBDBAImageTags_ReturnsError_WhenNonSemVerTag(t *testing.T) {
 	config := contentprovider.SecurityScanConfig{
-		Protecode: []string{
+		BDBA: []string{
 			"europe-docker.pkg.dev/kyma-project/dev/test-image:1.2.3",
 			"europe-docker.pkg.dev/kyma-project/dev/test-image:non-semver",
 		},
 	}
 
-	err := config.ValidateProtecodeImageTags()
+	err := config.ValidateBDBAImageTags()
 
 	require.ErrorIs(t, err, semver.ErrInvalidSemVer)
 }
 
-func Test_SecurityScanConfig_ValidateProtecodeImageTags_ReturnsNoError_WhenValidTagsProvided(t *testing.T) {
+func Test_SecurityScanConfig_ValidateBDBAImageTags_ReturnsNoError_WhenValidTagsProvided(t *testing.T) {
 	config := contentprovider.SecurityScanConfig{
-		Protecode: []string{
+		BDBA: []string{
 			"europe-docker.pkg.dev/kyma-project/dev/test-image:1.2.3",
 			"europe-docker.pkg.dev/kyma-project/dev/another-image:4.5.6",
 		},
 	}
 
-	err := config.ValidateProtecodeImageTags()
+	err := config.ValidateBDBAImageTags()
 
 	require.NoError(t, err)
-	assert.Len(t, config.Protecode, 2)
-	assert.Equal(t, "europe-docker.pkg.dev/kyma-project/dev/test-image:1.2.3", config.Protecode[0])
-	assert.Equal(t, "europe-docker.pkg.dev/kyma-project/dev/another-image:4.5.6", config.Protecode[1])
+	assert.Len(t, config.BDBA, 2)
+	assert.Equal(t, "europe-docker.pkg.dev/kyma-project/dev/test-image:1.2.3", config.BDBA[0])
+	assert.Equal(t, "europe-docker.pkg.dev/kyma-project/dev/another-image:4.5.6", config.BDBA[1])
 }
 
 func TestIsWhitelistedNonSemVerTags(t *testing.T) {

--- a/tests/e2e/create/testdata/sec-scanners-config/config.yaml
+++ b/tests/e2e/create/testdata/sec-scanners-config/config.yaml
@@ -1,7 +1,7 @@
 module-name: template-operator
 rc-tag: 1.0.1
 dev-branch: main
-protecode:
+bdba:
   - europe-docker.pkg.dev/kyma-project/prod/template-operator:1.0.1
   - europe-docker.pkg.dev/kyma-project/prod/template-operator:2.0.0
 whitesource:


### PR DESCRIPTION
**Description**

The attribute `protecode` in `sec-scanners-config.yaml` must be renamed to `bdba`

Changes proposed in this pull request:

- rename `protecode` to `bdba`
- adjust error messages
- adjust function/method names to reflect the change

**Related issue(s)**
Fixes #170 