### PR TITLE
docs: Add Documentation for Repository Landing Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ For example: `modulectl create -h`.
 
 Below are links to the detailed explanation of the commands, in case you want to know more about them without actually
 running the commands:
+- [modulectl](./docs/gen-docs/modulectl.md)
 - [Create Command](./docs/gen-docs/modulectl_create.md)
 - [Scaffold Command](./docs/gen-docs/modulectl_scaffold.md)
 - [Version Command](./docs/gen-docs/modulectl_version.md)

--- a/README.md
+++ b/README.md
@@ -1,29 +1,55 @@
 [![REUSE status](https://api.reuse.software/badge/github.com/kyma-project/modulectl)](https://api.reuse.software/info/github.com/kyma-project/modulectl)
-# modulectl
+# `modulectl`
 
 ## Overview
-`modulectl` is a command line tool which supports Kyma Module developers. It provides a set of commands and flags you can use to:
-- Create an emtpy scaffold for a new module
+It is a command line tool which supports Module developers for Kyma. It provides a set of commands and flags which can
+be used to:
+- Create an empty scaffold for a new module
 - Build a module and push it to a remote repository
 
-## Prerequisites
-> List the requirements to run the project or example.
+## How to Install
 
-## Installation
+From the GitHub releases page (https://github.com/kyma-project/modulectl/releases), download the binary for your operating system and architecture.
+Then, move the binary to a directory in your PATH.
+Or go inside the directory where the binary is located, and you can run the binary from there.
+Don't forget to make the binary executable by running `chmod +x modulectl`.
 
-> Explain the steps to install your project. If there are multiple installation options, mention the recommended one and include others in a separate document. Create an ordered list for each installation task.
+### Alternative
+You can build the binary from the source code.
+Clone the repository and run `make build` from the root directory of the repository.
+The binary will be created in the `bin` directory.
+> **Note**
 >
-> If it is an example README.md, describe how to build, run locally, and deploy the example. Format the example as code blocks and specify the language, highlighting where possible. Explain how you can validate that the example ran successfully. For example, define the expected output or commands to run which check a successful deployment.
->
-> Add subsections (H3) for better readability.
+> We also provide specific Makefile targets for MacOS (darwin) & Linux operating systems, with the options to compile
+> for x86 or ARM architectures.
+> You can use them to build the binary for your specific operating system and architecture.
 
 ## Usage
+```
+modulectl <command> [flags]
+```
 
-> Explain how to use the project. You can create multiple subsections (H3). Include the instructions or provide links to the related documentation.
+### Available Commands
+- `create` - Creates a module bundled as an OCI artifact. Detailed long explanation can be found here.
+- `scaffold` - Generates necessary files required for module creation.
+- `help` - Provides help about any command.
+- `version` - Print the version of the `modulectl` tool.
+- `completion` - Generate the autocompletion script for the specified shell.
+
+For detailed information about the commands, you can use the `-h` or `--help` flag with the command.
+For example: `modulectl create -h`.
+
+Below are links to the detailed explanation of the commands, in case you want to know more about them without actually
+running the commands:
+- [Create Command](./docs/gen-docs/modulectl_create.md)
+- [Scaffold Command](./docs/gen-docs/modulectl_scaffold.md)
+- [Version Command](./docs/gen-docs/modulectl_version.md)
 
 ## Development
 
-> Add instructions on how to develop the project or example. It must be clear what to do and, for example, how to trigger the tests so that other contributors know how to make their pull requests acceptable. Include the instructions or provide links to related documentation.
+Before you start developing, a local test setup must be created.
+To make life easy, we have written some scripts, which automate most of the process.
+Please follow [this guide](./docs/contributor/local-test-setup.md) to know more.
 
 ## Contributing
 <!--- mandatory section - do not change this! --->

--- a/README.md
+++ b/README.md
@@ -1,28 +1,27 @@
 [![REUSE status](https://api.reuse.software/badge/github.com/kyma-project/modulectl)](https://api.reuse.software/info/github.com/kyma-project/modulectl)
-# `modulectl`
+# modulectl
 
 ## Overview
-It is a command line tool which supports Module developers for Kyma. It provides a set of commands and flags which can
-be used to:
-- Create an empty scaffold for a new module
-- Build a module and push it to a remote repository
+modulectl is a command line tool that supports developers of Kyma modules. It provides a set of commands and flags to:
+* Create an empty scaffold for a new module
+* Build a module and push it to a remote repository
 
-## How to Install
+## Installation
 
-From the GitHub releases page (https://github.com/kyma-project/modulectl/releases), download the binary for your operating system and architecture.
-Then, move the binary to a directory in your PATH.
-Or go inside the directory where the binary is located, and you can run the binary from there.
-Don't forget to make the binary executable by running `chmod +x modulectl`.
+1. Download the binary for your operating system and architecture from the [GitHub releases page](https://github.com/kyma-project/modulectl/releases).
+2. Move the binary to a directory in your PATH or navigate to the directory where the binary is located.
+3. Make the binary executable by running `chmod +x modulectl`.
 
 ### Alternative
 You can build the binary from the source code.
+
 Clone the repository and run `make build` from the root directory of the repository.
-The binary will be created in the `bin` directory.
-> **Note**
+
+The binary is created in the `bin` directory.
+
+> [!NOTE]
 >
-> We also provide specific Makefile targets for MacOS (darwin) & Linux operating systems, with the options to compile
-> for x86 or ARM architectures.
-> You can use them to build the binary for your specific operating system and architecture.
+> You can use Makefile targets for MacOS (darwin) or Linux, with the option to compile for x86 or ARM architectures, to build the binary for your specific operating system and architecture.
 
 ## Usage
 ```
@@ -30,27 +29,17 @@ modulectl <command> [flags]
 ```
 
 ### Available Commands
-- `create` - Creates a module bundled as an OCI artifact. Detailed long explanation can be found here.
-- `scaffold` - Generates necessary files required for module creation.
-- `help` - Provides help about any command.
-- `version` - Print the version of the `modulectl` tool.
-- `completion` - Generate the autocompletion script for the specified shell.
+- `create` - Creates a module bundled as an OCI artifact. See [modulectl create](./docs/gen-docs/modulectl_create.md).
+- `scaffold` - Generates necessary files required for module creation. See [modulectl scaffold](./docs/gen-docs/modulectl_scaffold.md)
+- `help` - Provides help with any command.
+- `version` - Prints the current version of the modulectl tool. See [modulectl version](./docs/gen-docs/modulectl_version.md).
+- `completion` - Generates the autocompletion script for the specified shell.
 
-For detailed information about the commands, you can use the `-h` or `--help` flag with the command.
-For example: `modulectl create -h`.
-
-Below are links to the detailed explanation of the commands, in case you want to know more about them without actually
-running the commands:
-- [modulectl](./docs/gen-docs/modulectl.md)
-- [Create Command](./docs/gen-docs/modulectl_create.md)
-- [Scaffold Command](./docs/gen-docs/modulectl_scaffold.md)
-- [Version Command](./docs/gen-docs/modulectl_version.md)
+For detailed information about the commands, you can use the `-h` or `--help` flag with the command. For example: `modulectl create -h`.
 
 ## Development
 
-Before you start developing, a local test setup must be created.
-To make life easy, we have written some scripts, which automate most of the process.
-Please follow [this guide](./docs/contributor/local-test-setup.md) to know more.
+Before you start developing, create a local test setup. For more information, see [Configure and Run a Local Test Setup](./docs/contributor/local-test-setup.md).
 
 ## Contributing
 <!--- mandatory section - do not change this! --->


### PR DESCRIPTION
**Description**
Adds documentation for the landing page of the repository.

**Related issue(s)**
See also https://github.com/kyma-project/modulectl/issues/162
