### PR TITLE
docs: Add Claude Code baseline: CLAUDE.md

### DIFF
--- a/.claude/agents/principal-engineer.md
+++ b/.claude/agents/principal-engineer.md
@@ -1,0 +1,68 @@
+---
+name: principal-engineer
+description: Senior engineering design review. Use when you want judgment on whether an approach is sound — new CLI commands, service/tool architecture changes, OCI client behaviour, file I/O, significant refactors. CLI tools have different design concerns than operators: ergonomics, error messages, and supply chain security matter most. Invoke with: "Use the principal-engineer agent to review this design."
+tools: Read, Grep, Glob
+model: claude-opus-4-7
+color: purple
+maxTurns: 25
+---
+
+You are a principal software engineer reviewing changes to modulectl — a CLI tool for Kyma module developers. It packages modules into ModuleTemplate CRs and scaffolds boilerplate. Its users are developers, not operators; its outputs are release artifacts consumed by lifecycle-manager. Design concerns here are different from a long-running server.
+
+You have read-only access. Browse as much context as you need before forming an opinion.
+
+## What you evaluate
+
+### 1. Command → Service → Tools architecture
+- Business logic belongs in `internal/service/`, not in `cmd/`. Command files parse flags and call services. Is this boundary respected?
+- `cmd/modulectl/cmd.go` is the composition root — new dependencies are wired there via constructor injection, not instantiated inside services.
+- New tools (filesystem, network, git) belong in `tools/` or `internal/service/`, injected as interfaces.
+
+### 2. CLI ergonomics
+- Are flag names consistent with existing commands (`--module-config-file`, `--registry`, `--output`)?
+- Are error messages actionable? A developer hitting an error needs to know what to fix, not just that something failed. `fmt.Errorf("failed to read file: %w", err)` with the file path in context is better than `fmt.Errorf("read error: %w", err)`.
+- Are defaults sensible? Does the happy path require minimal flags?
+
+### 3. Supply chain security
+- modulectl fetches remote content (OCI images, URLs via `--gen-default-cr`). Is TLS verification enabled? `InsecureSkipVerify: true` in the OCI client is a supply-chain attack vector.
+- Are remote inputs validated before use?
+- Does the change introduce a new remote fetch path without TLS verification?
+
+### 4. File I/O safety
+- `filegenerator` writes output files from user-specified paths. Is path traversal possible — can a crafted module-config.yaml write files outside the intended output directory?
+- Does the change overwrite existing files without warning?
+
+### 5. Interface injection and testability
+- New external dependencies (filesystem, git, registry) must be injected as interfaces — never instantiated inside service structs.
+- Is the change unit-testable without a real registry or real git repo?
+- Are mocks in `internal/service/<name>/mocks/` up to date? (`make generate` regenerates them.)
+
+### 6. Generated docs gate
+- Any change to a flag name, description, or command structure must be followed by `make docs`.
+- `make validate-docs` is a CI gate — if it fails, the PR will be blocked.
+
+### 7. Simplicity
+- `scaffold` and `create` are the two operations. Does the change fit cleanly into one of them, or does it create a third conceptual path that needs its own command?
+- Is new functionality the minimum needed, or is it over-engineered for hypothetical future use?
+
+## Output format
+
+```
+## Principal Engineer Review
+
+### Design assessment
+[2-4 sentences on whether the approach fits the CLI architecture]
+
+### Concerns
+- [HIGH] <file>:<line> — <issue, especially supply chain or architecture boundary violations>
+- [MEDIUM] <file>:<line> — <concern>
+- [LOW] <file>:<line> — <observation>
+
+### What works well
+- <specific and concrete>
+
+### Verdict
+APPROVE / REQUEST CHANGES / REJECT
+
+[Decisive factor]
+```

--- a/.claude/cve-triage/context.md
+++ b/.claude/cve-triage/context.md
@@ -1,0 +1,96 @@
+# CVE Triage Context — modulectl
+
+modulectl is a **CLI tool** — it has no container image and no BDBA scan. CVE surface is entirely Go code: module dependencies (Mend) and source (Checkmarx).
+
+---
+
+## Surface 1: Container image (BDBA)
+
+**Not applicable.** modulectl distributes static Go binaries for four platforms (`darwin/linux × amd64/arm64`). There is no container image and no BDBA configuration in `sec-scanners-config.yaml`.
+
+---
+
+## Surface 2: Go module dependencies (Mend SCA findings)
+
+### Go module structure — single module
+
+- **Module**: `github.com/kyma-project/modulectl` (root `go.mod`)
+- No sub-modules
+
+Mend also excludes mocks: `**/mocks/**` (in addition to test files).
+
+### Go module CVE triage logic
+
+1. **Is the module in the dependency graph?**
+   ```sh
+   go list -m -json all | jq 'select(.Path == "<module>")'
+   ```
+
+2. **Is it reachable from production code?**
+   ```sh
+   go mod why <module>
+   ```
+   Chain passing only through `tests/e2e/`, `*_test.go`, or `mocks/` → **not applicable in production**.
+
+3. **Understand the user threat model:**
+   - modulectl runs as a developer tool on a local machine or CI runner — not a long-running server
+   - The highest-risk inputs are: OCI registry URLs, Kubernetes manifest files, module-config.yaml — all developer-supplied
+   - CVEs in HTTP client libraries (e.g., `go-containerregistry`) are higher priority than CVEs in logging libraries
+
+4. **Is there a fixed version?**
+   ```sh
+   go get <module>@<fixed-version>
+   go mod tidy
+   make test
+   ```
+   Open a `deps` PR. Title: `deps: bump <module> to <version> (CVE-XXXX-XXXXX)`
+   After a dependency bump: run `make docs && make validate-docs` — some CLI help text is generated and must stay in sync.
+
+5. **No FIPS constraint** — modulectl uses standard Go builds (`CGO_ENABLED=0`, no GOFIPS140).
+
+6. **No fix available?**
+   - Assess whether the vulnerable code path is reachable in normal developer usage
+   - CLI tools have a lower blast radius than server-side components — document the assessment and the runtime context
+   - Suppression requires security team approval
+
+---
+
+## Surface 3: Go source code (Checkmarx One SAST findings)
+
+### Checkmarx scope
+
+- Preset: `go-default`
+- Excludes: `**/test/**`, `**/*_test.go`, `**/mocks/**`
+- Scans: all production Go source
+
+### SAST triage logic
+
+1. **Understand the execution model:**
+   - modulectl is a CLI — it runs once, exits, does not serve HTTP (except outbound calls to OCI registries and git remotes)
+   - All "untrusted" input is developer-supplied (CLI flags, local files) — privilege escalation from external attackers is not the primary concern
+
+2. **Checkmarx patterns specific to this codebase:**
+   - `fileresolver` reads remote URLs (`--gen-default-cr` flag) and local paths — Checkmarx may flag `http.Get` calls or `os.ReadFile` with user-supplied paths
+     - These are intentional: the tool is designed to fetch remote content on developer instruction
+   - `filegenerator` writes files to paths from flags — Checkmarx may flag path construction
+     - Valid concern if path traversal escapes the intended output directory; verify sanitization
+
+3. **True positives to take seriously:**
+   - Any code that constructs a shell command from flag values (`exec.Command` with unsanitized input)
+   - Hardcoded credentials or tokens in non-test source
+   - `InsecureSkipVerify: true` in OCI registry client setup — this is a supply-chain risk (could allow a MITM to serve a malicious module image)
+   - `crypto/md5` or `crypto/sha1` used for security-relevant checksums (not just for content deduplication)
+
+4. **Generated docs gate:** After any fix that changes a flag name or description: run `make docs` to regenerate `docs/gen-docs/` — `make validate-docs` is a CI gate and will fail if docs drift.
+
+---
+
+## Scanner configuration reference
+
+Defined in `sec-scanners-config.yaml` (`kind: kcp`):
+
+| Scanner | Type | Scope | Excludes |
+|---|---|---|---|
+| **BDBA** | Container binary scan | **None** — no container image | — |
+| **Mend** | Go module SCA | Root `go.mod` | `test/`, `*_test.go`, `mocks/` |
+| **Checkmarx One** | Go SAST | All Go source (`go-default`) | `test/`, `*_test.go`, `mocks/` |

--- a/.claude/rules/go-conventions.md
+++ b/.claude/rules/go-conventions.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Go code conventions — modulectl
+
+`make lint` is the authoritative check. The full linter config is in `.golangci.yaml`.
+
+## Import aliases
+
+Strict aliases are enforced by `importas` — violations fail CI. The **complete alias list** is in `.golangci.yaml` under `linters-settings.importas.alias` (13 entries). Check that file before adding an import.
+
+## nolint policy
+
+Every `//nolint` directive **must** include an explanation:
+```go
+//nolint:funlen // service wiring — acceptable exception
+```
+Bare suppressions fail CI (`nolintlint` is enabled). Check `.golangci.yaml` before adding any.
+
+## Static binary
+
+All builds use `CGO_ENABLED=0` — no C dependencies. Do not add a dependency that requires cgo. Cross-compilation for all four targets (darwin/linux × amd64/arm64) must remain possible.
+
+## Generated mocks
+
+Mocks live in `internal/service/<name>/mocks/`. After changing an interface, run `make generate` to regenerate them. Stale mocks cause test failures that are hard to diagnose.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,3 +91,12 @@ Each command's `Use`, `Short`, `Long`, and `Example` strings live in embedded `.
 - E2E tests: `tests/e2e/` with Ginkgo, test the full CLI binary against a real local registry
 - `make test` runs only unit tests — safe to run anytime with no external setup
 - See `docs/contributor/local-test-setup.md` for full e2e environment setup
+
+## Model usage
+
+Follow the Kyma team's Claude Code workflow:
+
+- **Planning complex tasks** — switch to Opus: `/model claude-opus-4-7`
+- **Implementation** — use the default Sonnet: `/model claude-sonnet-4-6`
+
+Use Opus when you need to understand an unfamiliar subsystem, design a non-trivial change, or reason about cross-cutting impacts. Switch back to Sonnet once the approach is clear and you are writing code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+modulectl is a **CLI tool for Kyma module developers**. It automates the two most common tasks when building a Kyma module:
+
+1. **`scaffold`** — generate boilerplate files (module config, manifest, default CR, security config) for a new module
+2. **`create`** — package a module into a `ModuleTemplate` CR and component constructor YAML for release
+
+It is not a Kubernetes operator — there is no controller-runtime, no reconciler, no CRDs.
+
+## Module & language
+
+- Module: `github.com/kyma-project/modulectl` (Go 1.26.1)
+- CLI framework: `github.com/spf13/cobra` v1.10.2
+- Key dependencies: `go-git/v5` (git operations), `go-containerregistry` (image inspection), `lifecycle-manager/api` (ModuleTemplate types), `Masterminds/semver/v3` (version validation)
+
+## Make targets
+
+| Target | What it does |
+|---|---|
+| `make build` | Cross-compile for all 4 platforms (darwin/linux × amd64/arm64) into `bin/` |
+| `make build-darwin` | macOS amd64 only → `bin/modulectl-darwin` |
+| `make build-linux` | Linux amd64 only → `bin/modulectl-linux` |
+| `make test` | Unit tests with race detector, excludes e2e (fast, no external deps) |
+| `make lint` | golangci-lint |
+| `make docs` | Regenerate CLI documentation in `docs/gen-docs/` from cobra commands |
+| `make validate-docs` | Verify generated docs are up to date (CI gate) |
+
+**Version is injected at build time** from git: `<branch>-<short-sha>`. Pass `VERSION=v1.2.3` to `make build` for release builds.
+
+### Running a single test
+
+```sh
+go test -run TestFoo ./internal/service/create/...
+```
+
+E2E tests require a local Docker registry and are run separately:
+```sh
+./scripts/re-create-test-registry.sh   # one-time setup
+./scripts/build-modulectl.sh
+./scripts/run-e2e-test.sh --cmd=create    # or --cmd=scaffold
+```
+
+## Architecture
+
+### Command → Service → Tools
+
+```
+cmd/modulectl/
+  cmd.go            ← dependency injection / wiring (Cobra root command)
+  create/cmd.go     ← flag parsing, calls internal/service/create
+  scaffold/cmd.go   ← flag parsing, calls internal/service/scaffold
+
+internal/service/
+  create/           ← orchestrates module packaging
+  scaffold/         ← orchestrates file generation
+  moduleconfig/     ← parses/validates module-config.yaml
+  componentdescriptor/ ← builds OCM component descriptors
+  manifestparser/   ← extracts images from Kubernetes manifests
+  crdparser/        ← schema-validates default CRs against CRD definitions
+  git/              ← extracts commit info for component descriptors
+  image/            ← inspects OCI images via go-containerregistry
+  filegenerator/    ← writes output files
+  fileresolver/     ← resolves local paths and remote URLs to content
+
+tools/
+  filesystem/       ← file I/O utilities
+  yaml/             ← YAML marshalling helpers
+  io/               ← output formatting
+```
+
+`cmd/modulectl/cmd.go` is the **composition root** — all services are wired here via constructor injection. Keep business logic out of command files; they only parse flags and call services.
+
+### Command descriptions
+
+Each command's `Use`, `Short`, `Long`, and `Example` strings live in embedded `.txt` files inside the command directory (`use.txt`, `short.txt`, `long.txt`, `example.txt`). Edit those files, not the Go strings directly.
+
+## Code conventions
+
+- **All builds use `CGO_ENABLED=0`** — static binaries, no C dependencies
+- **Interface-driven design** throughout `internal/service/` — every external dependency (filesystem, git, image registry) is injected as an interface, enabling unit testing without real external systems
+- **Error types** live in `internal/common/errors/` — use typed errors, not `fmt.Errorf` with sentinel strings
+- **Generated docs** (`docs/gen-docs/`) must be kept in sync with cobra commands — `make validate-docs` fails CI if they drift. Always run `make docs` after changing command flags or descriptions.
+
+## Testing
+
+- Unit tests: co-located with source (`*_test.go` alongside each file), use `testify` and `gomega`
+- E2E tests: `tests/e2e/` with Ginkgo, test the full CLI binary against a real local registry
+- `make test` runs only unit tests — safe to run anytime with no external setup
+- See `docs/contributor/local-test-setup.md` for full e2e environment setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,10 @@ Each command's `Use`, `Short`, `Long`, and `Example` strings live in embedded `.
 - `make test` runs only unit tests — safe to run anytime with no external setup
 - See `docs/contributor/local-test-setup.md` for full e2e environment setup
 
+## CVE triage
+
+Two scanners run against this repo (`sec-scanners-config.yaml`): **Checkmarx One** (SAST) and **Mend** (Go module SCA). No BDBA — modulectl has no container image. When triaging a CVE finding, see [`.claude/cve-triage/context.md`](.claude/cve-triage/context.md).
+
 ## Model usage
 
 Follow the Kyma team's Claude Code workflow:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,10 @@ Each command's `Use`, `Short`, `Long`, and `Example` strings live in embedded `.
 - `make test` runs only unit tests — safe to run anytime with no external setup
 - See `docs/contributor/local-test-setup.md` for full e2e environment setup
 
+## Code conventions
+
+Go import aliases, nolint policy, and static-binary constraints load automatically when editing `.go` files — see [`.claude/rules/go-conventions.md`](.claude/rules/go-conventions.md).
+
 ## CVE triage
 
 Two scanners run against this repo (`sec-scanners-config.yaml`): **Checkmarx One** (SAST) and **Mend** (Go module SCA). No BDBA — modulectl has no container image. When triaging a CVE finding, see [`.claude/cve-triage/context.md`](.claude/cve-triage/context.md).


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at repo root so every Claude Code session starts with accurate context about this repo
- Covers: what modulectl does (scaffold + create CLI for Kyma module developers), make targets, cross-platform build output, single-test commands, the Command → Service → Tools architecture, composition root pattern in `cmd.go`, embedded command description files, `CGO_ENABLED=0` convention, interface-driven design for testability, generated docs gate, and e2e test setup

## Motivation

Part of the Jellyfish team initiative to add Claude Code baseline context to all team repos (see kyma-project/lifecycle-manager#3241). This is the modulectl complement to lifecycle-manager#3248.

## Test plan

- [ ] Open a Claude Code session in this repo and confirm `CLAUDE.md` loads with correct commands and architecture context