### PR TITLE
chore: Add `modulectl` tailored `renovate.json`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,12 @@
       "enabled": true
     },
     {
+      "matchManagers": ["gomod"],
+      "addLabels": ["go"],
+      "schedule": ["every day"],
+      "enabled": true
+    },
+    {
       "matchDatasources": ["golang-version"],
       "rangeStrategy": "bump"
     },
@@ -49,6 +55,16 @@
       "matchManagers": ["gomod"],
       "groupName": "All Kubernetes packages",
       "matchPackagePrefixes": ["k8s.io/", "sigs.k8s.io/"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "All Istio packages",
+      "matchPackagePrefixes": ["istio.io/"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "Ginkgo and Gomega",
+      "matchPackageNames": ["github.com/onsi/ginkgo/v2", "github.com/onsi/gomega"]
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "labels": ["area/dependency", "kind/chore"],
+  "commitMessagePrefix": "chore(renovate):",
   "gomod": {
     "postUpdateOptions": ["gomodTidy"],
     "enabled": true

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,64 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"],
+  "labels": ["area/dependency", "kind/chore"],
+  "gomod": {
+    "postUpdateOptions": ["gomodTidy"],
+    "enabled": true
+  },
+  "dockerfile": {
+    "enabled": false
+  },
+  "helm-values": {
+    "enabled": false
+  },
+  "kustomize": {
+    "enabled": false
+  },
+  "github-actions": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "matchCategories": ["golang"],
+      "postUpdateOptions": ["gomodTidy"],
+      "enabled": true
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"],
+      "schedule": "every month",
+      "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "All Kubernetes packages",
+      "matchPackagePrefixes": ["k8s.io/", "sigs.k8s.io/"]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["golangciLint: \"(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "golangci/golangci-lint"
+    }
+  ],
+  "ignorePaths": ["docs/**"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -54,12 +54,12 @@
     {
       "matchManagers": ["gomod"],
       "groupName": "All Kubernetes packages",
-      "matchPackagePrefixes": ["k8s.io/", "sigs.k8s.io/"]
+      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"]
     },
     {
       "matchManagers": ["gomod"],
       "groupName": "All Istio packages",
-      "matchPackagePrefixes": ["istio.io/"]
+      "matchPackageNames": ["istio.io/**"]
     },
     {
       "matchManagers": ["gomod"],

--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["golangciLint: \"(?<currentValue>[^\"]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
   "labels": ["area/dependency", "kind/chore"],
   "commitMessagePrefix": "chore(renovate):",
   "gomod": {


### PR DESCRIPTION
**Description**

Here I introduce `renovate.json` tailored for `modulectl`.

**Related issue(s)**
[Lifecycle Manager Issue 2995](https://github.com/kyma-project/lifecycle-manager/issues/2995)