### PR TITLE
fix: Exclude URLs from docker image reference parsing

### DIFF
--- a/internal/service/image/image.go
+++ b/internal/service/image/image.go
@@ -36,6 +36,11 @@ func IsImageReferenceCandidate(value string) bool {
 		return false
 	}
 
+	// Exclude values that look like URLs (e.g., contain "://") as docker image references do not include schemes.
+	if strings.Contains(value, "://") {
+		return false
+	}
+
 	hasTagOrDigest := false
 	for _, c := range value {
 		switch c {

--- a/internal/service/image/image_test.go
+++ b/internal/service/image/image_test.go
@@ -99,6 +99,11 @@ func TestIsImageReferenceCandidate_InvalidImages(t *testing.T) {
 			input:    "nginx\r:1.20",
 			expected: false,
 		},
+		{
+			name:     "contains protocol part",
+			input:    "http://api-server.myapp.svc.cluster.local:8080",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION


**Description**

Fixes #436 

**Related issue(s)**
#436 