### PR TITLE
feat: Introduce Original Image Preserving Label

### DIFF
--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -26,5 +26,5 @@ const (
 
 	RequiresDowntimeLabelKey = "operator.kyma-project.io/requiresDowntime"
 
-	OriginalImageReferenceLabelKey = "kyma-project.io/original-image-reference"
+	OriginalImageReferenceLabelKey = ProviderName + "/original-image-reference"
 )

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -25,4 +25,6 @@ const (
 	ModuleTemplateResourceName = "moduletemplate"
 
 	RequiresDowntimeLabelKey = "operator.kyma-project.io/requiresDowntime"
+
+	OriginalImageReferenceLabelKey = "kyma-project.io/original-image-reference"
 )

--- a/internal/common/types/component/constructor.go
+++ b/internal/common/types/component/constructor.go
@@ -154,6 +154,11 @@ func (c *Constructor) AddImageAsResource(imageInfos []*image.ImageInfo) {
 					Value:   common.ThirdPartyImageLabelValue,
 					Version: common.OCMVersion,
 				},
+				{
+					Name:    common.OriginalImageReferenceLabelKey,
+					Value:   imageInfo.FullURL,
+					Version: common.OCMVersion,
+				},
 			},
 			Access: &Access{
 				Type:           OCIArtifactAccessType,

--- a/internal/common/types/component/constructor_test.go
+++ b/internal/common/types/component/constructor_test.go
@@ -126,12 +126,15 @@ func TestConstructor_AddImageAsResource(t *testing.T) {
 	resource := constructor.Components[0].Resources[0]
 	require.Equal(t, component.OCIArtifactResourceType, resource.Type)
 	require.Equal(t, component.OCIArtifactResourceRelation, resource.Relation)
-	require.Len(t, resource.Labels, 1)
+	require.Len(t, resource.Labels, 2)
 
 	expectedLabelName := common.SecScanBaseLabelKey + "/" + common.TypeLabelKey
 	require.Equal(t, expectedLabelName, resource.Labels[0].Name)
 	require.Equal(t, common.ThirdPartyImageLabelValue, resource.Labels[0].Value)
 	require.Equal(t, common.OCMVersion, resource.Labels[0].Version)
+	require.Equal(t, common.OriginalImageReferenceLabelKey, resource.Labels[1].Name)
+	require.Equal(t, imageInfo.FullURL, resource.Labels[1].Value)
+	require.Equal(t, common.OCMVersion, resource.Labels[1].Version)
 	require.Equal(t, component.OCIArtifactAccessType, resource.Access.Type)
 	require.Equal(t, imageInfo.FullURL, resource.Access.ImageReference)
 }

--- a/internal/service/componentconstructor/componentconstructor_test.go
+++ b/internal/service/componentconstructor/componentconstructor_test.go
@@ -170,9 +170,12 @@ func TestService_AddImagesToConstructor_Success(t *testing.T) {
 			require.Equal(t, component.OCIArtifactAccessType, resource.Access.Type)
 			require.NotEmpty(t, resource.Access.ImageReference)
 			require.Len(t, resource.Labels, 2)
+			require.Equal(t, common.SecScanBaseLabelKey+"/"+common.TypeLabelKey, resource.Labels[0].Name)
 			require.Equal(t, common.ThirdPartyImageLabelValue, resource.Labels[0].Value)
+			require.Equal(t, common.OCMVersion, resource.Labels[0].Version)
 			require.Equal(t, common.OriginalImageReferenceLabelKey, resource.Labels[1].Name)
 			require.Equal(t, resource.Access.ImageReference, resource.Labels[1].Value)
+			require.Equal(t, common.OCMVersion, resource.Labels[1].Version)
 		}
 	}
 	require.Equal(t, len(images), imageResourceCount)

--- a/internal/service/componentconstructor/componentconstructor_test.go
+++ b/internal/service/componentconstructor/componentconstructor_test.go
@@ -169,8 +169,10 @@ func TestService_AddImagesToConstructor_Success(t *testing.T) {
 			require.NotEmpty(t, resource.Access)
 			require.Equal(t, component.OCIArtifactAccessType, resource.Access.Type)
 			require.NotEmpty(t, resource.Access.ImageReference)
-			require.Len(t, resource.Labels, 1)
+			require.Len(t, resource.Labels, 2)
 			require.Equal(t, common.ThirdPartyImageLabelValue, resource.Labels[0].Value)
+			require.Equal(t, common.OriginalImageReferenceLabelKey, resource.Labels[1].Name)
+			require.Equal(t, resource.Access.ImageReference, resource.Labels[1].Value)
 		}
 	}
 	require.Equal(t, len(images), imageResourceCount)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Introduced new label with the name `kyma-project.io/original-image-reference`
- This new label initially contains the same value as `.descriptor.component.resources[].access.imageReference`
- Tests have been also adjusted

**Related issue(s)**
Fixes #383 