### PR TITLE
fix: Use correct OCM v2 type names for artifact and access types

### DIFF
--- a/internal/common/types/component/constructor.go
+++ b/internal/common/types/component/constructor.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	GithubSourceType = "Github"
-	GithubAccessType = "gitHub"
+	GithubSourceType = "git"
+	GithubAccessType = "GitHub"
 
 	OCIArtifactResourceType     = "ociArtifact"
 	OCIArtifactResourceRelation = "external"
@@ -22,7 +22,7 @@ const (
 	DirectoryTreeResourceType = "directoryTree"
 	DirectoryInputType        = "dir"
 
-	PlainTextResourceType = "PlainText"
+	PlainTextResourceType = "plainText"
 	FileResourceInput     = "file"
 )
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- `GithubAccessType`: `"gitHub"` → `"GitHub"` — the v2 canonical access type per [OCM v2 bindings](https://github.com/open-component-model/open-component-model/blob/808b90c2343c4af26558ffbbe6a0c78bdf39b6dd/bindings/go/github/spec/access/v1/github.go#L10-L22); fixes the unrecognized type error reported by neighbors
- `GithubSourceType`: `"Github"` → `"git"` — correct OCM source type per [OCM v2 spec](https://github.com/open-component-model/open-component-model/blob/main/bindings/go/constructor/construct_source_test.go)
- `PlainTextResourceType`: `"PlainText"` → `"plainText"` — correct casing per [OCM artifact type constants](https://github.com/open-component-model/ocm/blob/main/api/ocm/extensions/artifacttypes/const.go)

**Related issue(s)**

Resolves #444